### PR TITLE
add `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-pymavlink>=2.4.14
-pyserial>=3.0
-numpy
-pynmeagps


### PR DESCRIPTION
Suppresses
```console
  DEPRECATION: Legacy editable install of MAVProxy==1.8.70 from file:///mnt/eagle-core/modules/MAVProxy (setup.py develop) is deprecated. pip 25.3 will enforce this behaviour change. A possible replacement is to add a pyproject.toml or enable --use-pep517, and use setuptools >= 64. If the resulting installation is not behaving as expected, try using --config-settings editable_mode=compat. Please consult the setuptools documentation for more information. Discussion can be found at https://github.com/pypa/pip/issues/11457
```